### PR TITLE
Add MIT license to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "zantolov/appbundle",
+  "license": "MIT",
   "authors": [
     {
       "name": "Zoran Antolovic",


### PR DESCRIPTION
MIT is a very free license. It means everybody can do everything with the code but it protects the core committers because the license says the software is provided "AS IS" and "WITHOUT ANY GUARANTIES".
